### PR TITLE
2-spaces indentation, added vendor folder with README.md, updated Gruntf...

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,7 @@ root = true
 
 [*]
 indent_style = space
-indent_size = 4
+indent_size = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/.jshintrc
+++ b/.jshintrc
@@ -6,7 +6,7 @@
     "curly": true,
     "eqeqeq": true,
     "immed": true,
-    "indent": 4,
+    "indent": 2,
     "latedef": true,
     "newcap": true,
     "noarg": true,

--- a/templates/common/Gruntfile.js
+++ b/templates/common/Gruntfile.js
@@ -231,6 +231,12 @@ module.exports = function (grunt) {
         cwd: '<%%= yeoman.app %>/styles',
         dest: '.tmp/styles/',
         src: '{,*/}*.css'
+      },
+      vendor: {
+        expand: true,
+        cwd: '<%%= yeoman.app %>/vendor',
+        dest: '.tmp/styles/',
+        src: '{,*/}*.css'
       }
     },
     
@@ -300,6 +306,7 @@ module.exports = function (grunt) {
       'clean:server',
       'bower-install',
       'concurrent:server',
+      'copy:vendor',
       'autoprefixer',
       'connect:livereload',
       'watch'
@@ -311,6 +318,7 @@ module.exports = function (grunt) {
     'bower-install',
     'useminPrepare',
     'concurrent:dist',
+    'copy:vendor',
     'autoprefixer',
     'concat',
     'copy:dist',

--- a/templates/common/root/.editorconfig
+++ b/templates/common/root/.editorconfig
@@ -3,7 +3,7 @@ root = true
 
 [*]
 indent_style = space
-indent_size = 4
+indent_size = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/templates/common/root/.jshintrc
+++ b/templates/common/root/.jshintrc
@@ -6,7 +6,7 @@
     "curly": true,
     "eqeqeq": true,
     "immed": true,
-    "indent": 4,
+    "indent": 2,
     "latedef": true,
     "newcap": true,
     "noarg": true,

--- a/templates/common/root/app/vendor/README.md
+++ b/templates/common/root/app/vendor/README.md
@@ -1,0 +1,15 @@
+# Why a vendor folder?
+
+In the past week, I had two independent occasions, where I needed to manually add JS / CSS files. The first time, with [MomentJS](http://momentjs.com/) the repo was even available through bower, but it included distinct versions of the library: a regular, a minified version, a version with languages, languages minified, and bower does not seem to have the option to choose one.
+
+The second time it was with a ionic specific repo, [ionic-contrib-frosted-glass](https://github.com/driftyco/ionic-contrib-frosted-glass) That one basically did not have a bower version.
+
+To make it easy, I added a vendor folder with Grunt support.
+
+## How does it work
+
+Really simple :) Both JS and CSS files can be added here. The CSS files will be copied to .tmp folder by the copy:vendor Grunt task. There, they will be processed by the autoprefixer task. The JS files are not processed at the moment. The files need to be inserted manually into index.html, I created wrappers.
+
+## How to disable
+
+When there is no file in the vendor folder, nothing happens. The Grunt task copy:vendor can also be removed from grunt serve and grunt build tasks.

--- a/templates/views/index.html
+++ b/templates/views/index.html
@@ -8,6 +8,10 @@
     <!-- build:css({.tmp,app}) styles/main.css -->
     <link rel="stylesheet" href="styles/main.css">
     <!-- endbuild -->
+    
+    <!-- custom vendor CSS -->
+    <!-- <link rel="stylesheet" href="styles/some.contrib.css"> -->
+    <!-- end custom vendor CSS -->
 
     <!-- cordova script (this will be a 404 during development) -->
     <script src="cordova.js"></script>
@@ -48,6 +52,10 @@
     <script src="bower_components/ionic/release/js/ionic-angular.js"></script>
     <!-- endbower -->
     <!-- endbuild -->
+    
+    <!-- custom vendor folder JS -->
+    <!-- <script src="vendor/someContribJs.js"></script> -->
+    <!-- end custom vendor JS -->
 
     <!-- build:js({.tmp,app}) scripts/scripts.js -->
     <script src="scripts/app.js"></script>


### PR DESCRIPTION
I added the 2-space indent we agreed upon, and also provided the vendor folder with Grunt support. In the last week, I had to manually add two libraries (JS and JS/CSS) manually, and it's not a no-brainer when there is no bower support, as there may be more to come. I agree with you diegonetto that libs should be added through bower, but sometimes there is no support for bower. Perhaps it won't be needed in the future, but at the moment I use it with http://momentjs.com/ (min + lang version, provided by bower but not possible to include via bower) and https://github.com/driftyco/ionic-contrib-frosted-glass which is not provided by bower.

I added a README.md file to the folder, that provides arguments for it's addition :) and also easy instructions on how to use it.
