### PR TITLE
Add "karma:unit:start" to "grunt serve" task

### DIFF
--- a/templates/common/Gruntfile.js
+++ b/templates/common/Gruntfile.js
@@ -392,6 +392,7 @@ module.exports = function (grunt) {
       'concurrent:server',
       'autoprefixer',
       'connect:livereload',
+      'karma:unit:start',
       'watch'
     ]);
   });


### PR DESCRIPTION
If you run the `grunt serve` task and then edit a file, this error pops up:

```
There is no server listening on port 8080
Warning: Task "karma:unit:run" failed. Use --force to continue.

Aborted due to warnings.
```

Adding `karma:unit:start` to the `grunt serve` task solves this issue (every time i edit a file, tests are executed correctly).

P.S.: thanks for your generator, very nice job!
