### PR TITLE
bower_components directory shouldn't be watched

### DIFF
--- a/templates/common/Gruntfile.js
+++ b/templates/common/Gruntfile.js
@@ -47,7 +47,8 @@ module.exports = function (grunt) {
           livereload: '<%%= connect.options.livereload %>'
         },
         files: [
-          '<%%= yeoman.app %>/**/*.html',
+          '<%= yeoman.app %>/*.html',
+          '<%= yeoman.app %>/templates/**/*.html',
           '.tmp/styles/**/*.css',
           '<%%= yeoman.app %>/images/**/*.{png,jpg,jpeg,gif,webp,svg}'
         ]


### PR DESCRIPTION
From #14 

Grunt now "watches" html files only in the root directory of the app or in the "templates" directory. This should increase performance, because grunt won't watch the `bower_components` directory anymore. (https://github.com/gruntjs/grunt-contrib-watch/blob/3ec9cd8d7f91262ddb713a2f0968eb08067135b3/README.md#why-is-the-watch-devouring-all-my-memory)
