### PR TITLE
Allow outside access as default

### DIFF
--- a/templates/common/Gruntfile.js
+++ b/templates/common/Gruntfile.js
@@ -63,8 +63,8 @@ module.exports = function (grunt) {
     connect: {
       options: {
         port: 9000,
-        // Change this to '0.0.0.0' to access the server from outside.
-        hostname: 'localhost',
+        // Change this to 'localhost' to deny access the server from outside.
+        hostname: '0.0.0.0',
         livereload: 35729
       },
       livereload: {


### PR DESCRIPTION
Most of the time I'm testing my app on my phone, through the local network
