### PR TITLE
refactor(grunt:ripple): remove superfluous cordova prepare

### DIFF
--- a/templates/common/Gruntfile.js
+++ b/templates/common/Gruntfile.js
@@ -122,7 +122,7 @@ module.exports = function (grunt) {
       },
       server: '.tmp'
     },
-    
+
     autoprefixer: {
       options: {
         browsers: ['last 1 version']
@@ -144,7 +144,7 @@ module.exports = function (grunt) {
         ignorePath: '<%%= yeoman.app %>/'
       }
     },
-    
+
     <% if (compass) { %>
     // Compiles Sass to CSS and generates necessary files if requested
     compass: {
@@ -275,7 +275,7 @@ module.exports = function (grunt) {
         dest: 'www/'
       }
     },
-    
+
     concurrent: {
       server: [<% if (compass) { %>
         'compass:server',<% } %>
@@ -412,14 +412,13 @@ module.exports = function (grunt) {
 
   // Since Apache Ripple serves assets directly out of their respective platform
   // directories, we watch all registered files and then copy all un-built assets
-  // over to www/. Last step is running ordova prepare so we can refresh the ripple
-  // browser tab to see the changes.
-  grunt.registerTask('ripple', ['bower-install', 'copy:all', 'prepare', 'ripple-emulator']);
+  // over to www/. Ripple will execute 'cordova prepare' on browser refresh.
+  grunt.registerTask('ripple', ['bower-install', 'copy:all', 'ripple-emulator']);
   grunt.registerTask('ripple-emulator', function () {
     grunt.config.set('watch', {
       all: {
         files: _.flatten(_.pluck(grunt.config.get('watch'), 'files')),
-        tasks: ['copy:all', 'prepare']
+        tasks: ['copy:all']
       }
     });
 

--- a/templates/common/_package.json
+++ b/templates/common/_package.json
@@ -32,7 +32,7 @@
     "time-grunt": "~0.2.1",
     "cordova": "~3.4.0-0.1.3",
     "lodash": "~2.4.1",
-    "ripple-emulator": "~0.9.20"
+    "ripple-emulator": "~0.9.23"
   },
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
Ripple executes _cordova prepare_ internally on browser refresh (see [node_modules/ripple-emulator/lib/server/emulate/hosted.js](https://github.com/apache/incubator-ripple/blob/master/lib/server/emulate/hosted.js)). Thus, it's not necessary to call the Grunt _prepare_ task to move files from www/ to the respective platform www directories.
