### PR TITLE
chore(gen:deps): change from ngmin to ngAnnotate

### DIFF
--- a/templates/common/Gruntfile.js
+++ b/templates/common/Gruntfile.js
@@ -368,10 +368,9 @@ module.exports = function (grunt) {
       }
     },
 
-    // ngmin tries to make the code safe for minification automatically by
-    // using the Angular long form for dependency injection. It doesn't work on
-    // things like resolve or inject so those have to be done manually.
-    ngmin: {
+    // ngAnnotate tries to make the code safe for minification automatically by
+    // using the Angular long form for dependency injection.
+    ngAnnotate: {
       dist: {
         files: [{
           expand: true,
@@ -480,7 +479,7 @@ module.exports = function (grunt) {
     'concurrent:dist',
     'autoprefixer',
     'concat',
-    'ngmin',
+    'ngAnnotate',
     'copy:dist',
     'cssmin',
     'uglify',

--- a/templates/common/_package.json
+++ b/templates/common/_package.json
@@ -19,7 +19,7 @@
     "grunt-contrib-watch": "~0.5.2",
     "grunt-newer": "~0.6.1",
     "grunt-usemin": "~2.0.0",
-    "grunt-ngmin": "~0.0.2",
+    "grunt-ng-annotate": "~0.2.3",
     "grunt-karma": "~0.8.0",
     "karma": "~0.12.0",
     "karma-mocha": "~0.1.3",


### PR DESCRIPTION
ngmin is being deprecated in favor of ngAnnotate. ngAnnotate is much faster, better maintained, and covers more use cases.

the ngmin api is a subset of the ngAnnotate api, so there should be no breaking changes. Closes #59
