### PR TITLE
'grunt cordova' command is not clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ Running `grunt serve` enhances your workflow by allowing you to rapidly build Io
 ### Building assets for Cordova
 Once you're ready to test your application in a simulator or device, run `grunt cordova` to copy all of your `app/` assets into `www/` and build updated `platform/` files so they are ready to be emulated / run by Cordova.
 
+```
+grunt cordova
+```
+
 To compress and optimize your application, run `grunt build`. It will concatenate, obfuscate, and minify your JavaScript, HTML, and CSS files and copy over the resulting assets into the `www/` directory so the compressed version can be used with Cordova.
 
 ### Cordova commands


### PR DESCRIPTION
Most commands have their own line and are clear when someone is skimming through the documentation, however 'grunt cordova' is easily missed as it is inline with the instructions. It would be more consistent to have it on it's own line so that it's easily detectable. I missed it and it took me a few times to realize it.
