### PR TITLE
Using win-spawn instead of child_process for win32

### DIFF
--- a/templates/common/Gruntfile.js
+++ b/templates/common/Gruntfile.js
@@ -4,7 +4,7 @@
 var _ = require('lodash');
 var path = require('path');
 var cordovaCli = require('cordova');
-var spawn = require('child_process').spawn;
+var spawn = process.platform === 'win32' ? require('win-spawn') : require('child_process').spawn;
 
 module.exports = function (grunt) {
 


### PR DESCRIPTION
Build fails with error message "Fatal error: spawn ENOENT" on win32 machines when using child_process module to spawn, changed to use win-spawn instead. 