### PR TITLE
fix(gen): Set version to 0.1.0 in bower.json template.

### DIFF
--- a/templates/common/_bower.json
+++ b/templates/common/_bower.json
@@ -1,6 +1,6 @@
 {
   "name": "<%= appName %>",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "dependencies": {
     "ionic": "v1.0.0-beta.13"
   },


### PR DESCRIPTION
We're already using 0.1.0 in the package.json template. This synchronizes these numbers.