### PR TITLE
fix(gen): Mark some gitignore entries absolute.

### DIFF
--- a/templates/common/_gitignore
+++ b/templates/common/_gitignore
@@ -1,15 +1,15 @@
-node_modules
-www
+/node_modules
+/www
 .idea
-.temp
-.sass-cache
-<%= appPath %>/bower_components
-coverage
-platforms
-plugins
+/.temp
+/.sass-cache
+/<%= appPath %>/bower_components
+/coverage
+/platforms
+/plugins
 *.swp
 *.swo
 *.log
 *.DS_Store
 
-app/scripts/configuration.js
+/app/scripts/configuration.js


### PR DESCRIPTION
To ensure git does not ignore files in subdirectory, this commit restricts some entries to the root directory only.
