### PR TITLE
Adding ionicons to the dependencies

### DIFF
--- a/templates/common/_bower.json
+++ b/templates/common/_bower.json
@@ -3,7 +3,8 @@
   "version": "0.0.0",
   "dependencies": {
     "ionic": "v1.0.0-beta.14",
-    "ngCordova": "0.1.12-alpha"
+    "ngCordova": "0.1.12-alpha",
+    "ionicons": "~2.0.1"
   },
   "devDependencies": {
     "angular-mocks": "~1.3.6",


### PR DESCRIPTION
When creating a new app and selecting a tabbed UI, the ionicons are not loaded (because they were left out from the dependencies).,