### PR TITLE
Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
-sudo: required
 language: node_js
 node_js:
   - '0.12'
   - '0.11'
   - '0.10'
-  - '0.8'
 before_install:
   - currentfolder=${PWD##*/}
   - if [ "$currentfolder" != 'generator-ionic' ]; then cd .. && eval "mv $currentfolder generator-ionic" && cd generator-ionic; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
+sudo: required
 language: node_js
 node_js:
+  - '0.12'
+  - '0.11'
   - '0.10'
+  - '0.8'
 before_install:
   - currentfolder=${PWD##*/}
   - if [ "$currentfolder" != 'generator-ionic' ]; then cd .. && eval "mv $currentfolder generator-ionic" && cd generator-ionic; fi


### PR DESCRIPTION
chore(build): add more node versions to .travis.yml

`.travis.yml` change to include more node versions to be assured of backwards-compatibility.

no breaking changes and no issues to reference.