### PR TITLE
fix the file filtering rule of '!**/*.(scss,sass,css)'

### DIFF
--- a/templates/common/_Gruntfile.js
+++ b/templates/common/_Gruntfile.js
@@ -294,7 +294,7 @@ module.exports = function (grunt) {
         dest: '<%%= yeoman.dist %>/',
         src: [
           '**/*',
-          '!**/*.(scss,sass,css)',
+          '!**/*.{scss,sass,css}',
         ]
       },
       tmp: {


### PR DESCRIPTION
in task copy:app, it's supposedly to filter out files of styles, such as scss, sass & css. However, according to http://gruntjs.com/configuring-tasks#globbing-patterns

This syntax using '()' is incorrect, instead, {} should be used, e.g., '!**/*.{scss,sass,css}' as in my fix.