### PR TITLE
fix(hooks): fix for update_platform_config.js documentation example

### DIFF
--- a/templates/hooks/after_prepare/update_platform_config.js
+++ b/templates/hooks/after_prepare/update_platform_config.js
@@ -41,7 +41,7 @@
         <preference name="android-configChanges" value="orientation" />
         <preference name="android-theme" value="@android:style/Theme.Black.NoTitleBar" />
 
-        <config-file target="AndroidManifest.xml" parent="/">
+        <config-file target="AndroidManifest.xml" parent="/*">
             <supports-screens
                 android:xlargeScreens="false"
                 android:largeScreens="false"

--- a/templates/hooks/after_prepare/update_platform_config.js
+++ b/templates/hooks/after_prepare/update_platform_config.js
@@ -41,7 +41,7 @@
         <preference name="android-configChanges" value="orientation" />
         <preference name="android-theme" value="@android:style/Theme.Black.NoTitleBar" />
 
-        <config-file target="AndroidManifest.xml" parent="/*>
+        <config-file target="AndroidManifest.xml" parent="/">
             <supports-screens
                 android:xlargeScreens="false"
                 android:largeScreens="false"


### PR DESCRIPTION
fix(hooks): fix for update_platform_config.js documentation example

Fix for the example included in the update_platform_config after prepare hook documentation not properly closing the config-file XML tag.

