### PR TITLE
Only handle supported platforms

### DIFF
--- a/templates/hooks/after_prepare/update_platform_config.js
+++ b/templates/hooks/after_prepare/update_platform_config.js
@@ -337,6 +337,8 @@ var platformConfig = (function(){
                 platform = platform.trim().toLowerCase();
                 if(platform == 'android' || platform == 'ios'){
                     platformConfig.updatePlatformConfig(platform);
+                } else {
+                    console.log('Platform "' + platform + '" not supported by this hook.');
                 }
             } catch (e) {
                 process.stdout.write(e);

--- a/templates/hooks/after_prepare/update_platform_config.js
+++ b/templates/hooks/after_prepare/update_platform_config.js
@@ -335,7 +335,9 @@ var platformConfig = (function(){
         _.each(platforms, function (platform) {
             try {
                 platform = platform.trim().toLowerCase();
-                platformConfig.updatePlatformConfig(platform);
+                if(platform == 'android' || platform == 'ios'){
+                    platformConfig.updatePlatformConfig(platform);
+                }
             } catch (e) {
                 process.stdout.write(e);
             }


### PR DESCRIPTION
When you have a project with more platforms than only android and iOS, this hook fail. This fixes it. I did not add a empty object to the defined `preferenceMappingData`, as other platforms are really not supported.  