### PR TITLE
Update to current Ionic, ngCordova, and fix grunt-concurrent versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Run `yo ionic`, optionally passing an app name:
 yo ionic [app-name]
 ```
 
-Run `grunt` for building / compressing your Ionic app, `grunt serve` for a browser preview, and `grunt serve:compress` for a preview of the optimized application.
+Run `grunt` for building / compressing your Ionic app, `grunt serve` for a browser preview, and `grunt serve:compress` for a preview of the optimized application. *(If grunt doesn't serve the application after running `grunt serve` with 'succes', refer to [#223](https://github.com/diegonetto/generator-ionic/issues/223).)*
 
 ## Upgrading
 Make sure you've committed (or backed up) your local changes and install the latest version of the generator via `npm install -g generator-ionic`, then go ahead and re-run `yo ionic` inside your project's directory.

--- a/templates/common/_bower.json
+++ b/templates/common/_bower.json
@@ -2,8 +2,8 @@
   "name": "<%= appName %>",
   "version": "0.0.0",
   "dependencies": {
-    "ionic": "v1.0.0-rc.3",
-    "ngCordova": "v0.1.14-alpha"
+    "ionic": "v1.0.1",
+    "ngCordova": "v0.1.17-alpha"
   },
   "devDependencies": {
     "angular-mocks": "~1.3.6",

--- a/templates/common/_package.json
+++ b/templates/common/_package.json
@@ -8,8 +8,8 @@
     "glob": "~4.3.5",
     "grunt-autoprefixer": "~2.2.0",
     "grunt-wiredep": "^2.0.0",
-    "ionic": "^1.3.7",
-    "grunt-concurrent": "~1.0.0",
+    "ionic": "^1.6.4",
+    "grunt-concurrent": "1.0.0",
     "grunt-contrib-clean": "~0.6.0",<% if (compass) { %>
     "grunt-contrib-compass": "~1.0.1",<% } %>
     "grunt-contrib-concat": "~0.5.0",


### PR DESCRIPTION
This is a simple versioning fix that will bring users up to the current versions of Ionic, ngCordova, as well as fix the grunt-concurrent versioning issues.